### PR TITLE
build(deps): bump undici and firebase

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@types/react-beautiful-dnd": "^13.1.8",
         "axios": "^1.6.7",
-        "firebase": "^10.8.0",
+        "firebase": "^10.8.1",
         "firebase-tools": "^13.2.0",
         "moment": "^2.30.1",
         "next": "14.1.0",
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "engines": {
         "node": ">=14"
       }
@@ -224,9 +224,9 @@
       "integrity": "sha512-iRP+QKI2+oz3UAh4nPEq14CsEjrjD6a5+fuypjScisAh9kXKFvdJOZJDwk7kikLvWVLGEs9+kIUS4LPQV7VZVw=="
     },
     "node_modules/@firebase/app": {
-      "version": "0.9.27",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.27.tgz",
-      "integrity": "sha512-p2Dvl1ge4kRsyK5+wWcmdAIE9MSwZ0pDKAYB51LZgZuz6wciUZk4E1yAEdkfQlRxuHehn+Ol9WP5Qk2XQZiHGg==",
+      "version": "0.9.28",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.28.tgz",
+      "integrity": "sha512-MS0+EtNixrwJbVDs5Bt/lhUhzeWGUtUoP6X+zYZck5GAZwI5g4F91noVA9oIXlFlpn6Q1xIbiaHA2GwGk7/7Ag==",
       "dependencies": {
         "@firebase/component": "0.6.5",
         "@firebase/logger": "0.4.0",
@@ -276,11 +276,11 @@
       "integrity": "sha512-uwSUj32Mlubybw7tedRzR24RP8M8JUVR3NPiMk3/Z4bCmgEKTlQBwMXrehDAZ2wF+TsBq0SN1c6ema71U/JPyQ=="
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.2.27",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.27.tgz",
-      "integrity": "sha512-SYlqocfUDKPHR6MSFC8hree0BTiWFu5o8wbf6zFlYXyG41w7TcHp4wJi4H/EL5V6cM4kxwruXTJtqXX/fRAZtw==",
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.28.tgz",
+      "integrity": "sha512-Mr2NbeM1Oaayuw5unUAMzt+7/MN+e2uklT1l87D+ZLJl2UvhZAZmMt74GjEI9N3sDYKMeszSbszBqtJ1fGVafQ==",
       "dependencies": {
-        "@firebase/app": "0.9.27",
+        "@firebase/app": "0.9.28",
         "@firebase/component": "0.6.5",
         "@firebase/logger": "0.4.0",
         "@firebase/util": "1.9.4",
@@ -293,15 +293,15 @@
       "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
     },
     "node_modules/@firebase/auth": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.6.0.tgz",
-      "integrity": "sha512-Qhl35eJTV6BwvuueTPCY6x8kUlYyzALtjp/Ws0X3fw3AnjVVfuVb7oQ3Xh5VPVfMFhaIuUAd1KXwcAuIklkSDw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.6.1.tgz",
+      "integrity": "sha512-oOuQVOxtxKr+kTTqEkkI2qXIeGbkNLpA8FzO030LF4KXmMcETqsPaIqw7Aw1Y4Zl82l1qpZtpc4vN4Da2qZdfQ==",
       "dependencies": {
         "@firebase/component": "0.6.5",
         "@firebase/logger": "0.4.0",
         "@firebase/util": "1.9.4",
         "tslib": "^2.1.0",
-        "undici": "5.26.5"
+        "undici": "5.28.3"
       },
       "peerDependencies": {
         "@firebase/app": "0.x",
@@ -314,16 +314,16 @@
       }
     },
     "node_modules/@firebase/auth-compat": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.2.tgz",
-      "integrity": "sha512-pRgje5BPCNR1vXyvGOVXwOHtv88A2WooXfklI8sV7/jWi03ExFqNfpJT26GUo/oD39NoKJ3Kt6rD5gVvdV7lMw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.5.3.tgz",
+      "integrity": "sha512-2pVtVEvu8P7SF6jSPfLPKWUClQFj+StqAZ0fD/uQ6mv8DyWn7AuuANFEu7Pv96JPcaL6Gy9jC5dFqjpptjqSRA==",
       "dependencies": {
-        "@firebase/auth": "1.6.0",
+        "@firebase/auth": "1.6.1",
         "@firebase/auth-types": "0.12.0",
         "@firebase/component": "0.6.5",
         "@firebase/util": "1.9.4",
         "tslib": "^2.1.0",
-        "undici": "5.26.5"
+        "undici": "5.28.3"
       },
       "peerDependencies": {
         "@firebase/app-compat": "0.x"
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.4.2.tgz",
-      "integrity": "sha512-YaX6ypa/RzU6OkxzUQlpSxwhOIWdTraCNz7sMsbaSEjjl/pj/QvX6TqjkdWGzuBYh2S6rz7ErhDO0g39oZZw/g==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.4.3.tgz",
+      "integrity": "sha512-Ix61zbeuTsHf0WFbk6+67n89Vzd9M8MMTdnz7c7z+BRE3BS5Vuc3gX5ZcHFjqPkQJ7rpLB1egHsYe4Przp5C2g==",
       "dependencies": {
         "@firebase/component": "0.6.5",
         "@firebase/logger": "0.4.0",
@@ -400,7 +400,7 @@
         "@grpc/grpc-js": "~1.9.0",
         "@grpc/proto-loader": "^0.7.8",
         "tslib": "^2.1.0",
-        "undici": "5.26.5"
+        "undici": "5.28.3"
       },
       "engines": {
         "node": ">=10.10.0"
@@ -410,12 +410,12 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.25.tgz",
-      "integrity": "sha512-+xI7WmsgZCBhMn/+uhDKcg+lsOUJ9FJyt5PGTzkFPbCsozWfeQZ7eVnfPh0rMkUOf0yIQ924RIe04gwvEIbcoQ==",
+      "version": "0.3.26",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.26.tgz",
+      "integrity": "sha512-dNrKiH5Cn6ItANV9nJI2Y0msKBj/skO7skDlRo/BUSQE1DKbNzumxpJEz+PK/PV1nTegnRgVvs47gpQeVWXtYQ==",
       "dependencies": {
         "@firebase/component": "0.6.5",
-        "@firebase/firestore": "4.4.2",
+        "@firebase/firestore": "4.4.3",
         "@firebase/firestore-types": "3.0.0",
         "@firebase/util": "1.9.4",
         "tslib": "^2.1.0"
@@ -434,9 +434,9 @@
       }
     },
     "node_modules/@firebase/functions": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.1.tgz",
-      "integrity": "sha512-3uUa1hB79Gmy6E1gHTfzoHeZolBeHc/I/n3+lOCDe6BOos9AHmzRjKygcFE/7VA2FJjitCE0K+OHI6+OuoY8fQ==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.11.2.tgz",
+      "integrity": "sha512-2NULTYOZbu0rXczwfYdqQH0w1FmmYrKjTy1YPQSHLCAkMBdfewoKmVm4Lyo2vRn0H9ZndciLY7NszKDFt9MKCQ==",
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.0",
         "@firebase/auth-interop-types": "0.2.1",
@@ -444,19 +444,19 @@
         "@firebase/messaging-interop-types": "0.2.0",
         "@firebase/util": "1.9.4",
         "tslib": "^2.1.0",
-        "undici": "5.26.5"
+        "undici": "5.28.3"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/functions-compat": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.7.tgz",
-      "integrity": "sha512-uXe6Kmku5lNogp3OpPBcOJbSvnaCOn+YxS3zlXKNU6Q/NLwcvO3RY1zwYyctCos2RemEw3KEQ7YdzcECXjHWLw==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.8.tgz",
+      "integrity": "sha512-VDHSw6UOu8RxfgAY/q8e+Jn+9Fh60Fc28yck0yfMsi2e0BiWgonIMWkFspFGGLgOJebTHl+hc+9v91rhzU6xlg==",
       "dependencies": {
         "@firebase/component": "0.6.5",
-        "@firebase/functions": "0.11.1",
+        "@firebase/functions": "0.11.2",
         "@firebase/functions-types": "0.6.0",
         "@firebase/util": "1.9.4",
         "tslib": "^2.1.0"
@@ -623,26 +623,26 @@
       "integrity": "sha512-RtEH4vdcbXZuZWRZbIRmQVBNsE7VDQpet2qFvq6vwKLBIQRQR5Kh58M4ok3A3US8Sr3rubYnaGqZSurCwI8uMA=="
     },
     "node_modules/@firebase/storage": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.12.1.tgz",
-      "integrity": "sha512-KJ5NV7FUh54TeTlEjdkTTX60ciCKOp9EqlbLnpdcXUYRJg0Z4810TXbilPc1z7fTIG4iPjtdi95bGE9n4dBX8A==",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.12.2.tgz",
+      "integrity": "sha512-MzanOBcxDx9oOwDaDPMuiYxd6CxcN1xZm+os5uNE3C1itbRKLhM9rzpODDKWzcbnHHFtXk3Q3lsK/d3Xa1WYYw==",
       "dependencies": {
         "@firebase/component": "0.6.5",
         "@firebase/util": "1.9.4",
         "tslib": "^2.1.0",
-        "undici": "5.26.5"
+        "undici": "5.28.3"
       },
       "peerDependencies": {
         "@firebase/app": "0.x"
       }
     },
     "node_modules/@firebase/storage-compat": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.4.tgz",
-      "integrity": "sha512-Y0m5e2gS/wB9Ioth2X/Sgz76vcxvqgQrCmfa9qwhss/N31kxY2Gks6Frv0nrE18AjVfcSmcfDitqUwxcMOTRSg==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.5.tgz",
+      "integrity": "sha512-5dJXfY5NxCF5NAk4dLvJqC+m6cgcf0Fr29nrMHwhwI34pBheQq2PdRZqALsqZCES9dnHTuFNlqGQDpLr+Ph4rw==",
       "dependencies": {
         "@firebase/component": "0.6.5",
-        "@firebase/storage": "0.12.1",
+        "@firebase/storage": "0.12.2",
         "@firebase/storage-types": "0.8.0",
         "@firebase/util": "1.9.4",
         "tslib": "^2.1.0"
@@ -4718,25 +4718,25 @@
       }
     },
     "node_modules/firebase": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.8.0.tgz",
-      "integrity": "sha512-UJpC24vw8JFuHEOQyArBGKTUd7+kohLISCzHyn0M/prP0KOTx2io1eyLliEid330QqnWI7FOlPxoU97qecCSfQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.8.1.tgz",
+      "integrity": "sha512-4B2jzhU/aumfKL446MG41/T5+t+9d9urf5XGrjC0HRQUm4Ya/amV48HBchnje69ExaJP5f2WxO9OX3wh9ee4wA==",
       "dependencies": {
         "@firebase/analytics": "0.10.1",
         "@firebase/analytics-compat": "0.2.7",
-        "@firebase/app": "0.9.27",
+        "@firebase/app": "0.9.28",
         "@firebase/app-check": "0.8.2",
         "@firebase/app-check-compat": "0.3.9",
-        "@firebase/app-compat": "0.2.27",
+        "@firebase/app-compat": "0.2.28",
         "@firebase/app-types": "0.9.0",
-        "@firebase/auth": "1.6.0",
-        "@firebase/auth-compat": "0.5.2",
+        "@firebase/auth": "1.6.1",
+        "@firebase/auth-compat": "0.5.3",
         "@firebase/database": "1.0.3",
         "@firebase/database-compat": "1.0.3",
-        "@firebase/firestore": "4.4.2",
-        "@firebase/firestore-compat": "0.3.25",
-        "@firebase/functions": "0.11.1",
-        "@firebase/functions-compat": "0.3.7",
+        "@firebase/firestore": "4.4.3",
+        "@firebase/firestore-compat": "0.3.26",
+        "@firebase/functions": "0.11.2",
+        "@firebase/functions-compat": "0.3.8",
         "@firebase/installations": "0.6.5",
         "@firebase/installations-compat": "0.2.5",
         "@firebase/messaging": "0.12.6",
@@ -4745,8 +4745,8 @@
         "@firebase/performance-compat": "0.2.5",
         "@firebase/remote-config": "0.4.5",
         "@firebase/remote-config-compat": "0.2.5",
-        "@firebase/storage": "0.12.1",
-        "@firebase/storage-compat": "0.3.4",
+        "@firebase/storage": "0.12.2",
+        "@firebase/storage-compat": "0.3.5",
         "@firebase/util": "1.9.4"
       }
     },
@@ -10403,9 +10403,9 @@
       "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/undici": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.5.tgz",
-      "integrity": "sha512-cSb4bPFd5qgR7qr2jYAi0hlX9n5YKK2ONKkLFkxl+v/9BvC0sOpZjBHDBSXc5lWAf5ty9oZdRXytBIHzgUcerw==",
+      "version": "5.28.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
+      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@types/react-beautiful-dnd": "^13.1.8",
     "axios": "^1.6.7",
-    "firebase": "^10.8.0",
+    "firebase": "^10.8.1",
     "firebase-tools": "^13.2.0",
     "moment": "^2.30.1",
     "next": "14.1.0",


### PR DESCRIPTION
Bumps [undici](https://github.com/nodejs/undici) to 5.28.3 and updates ancestor dependency [firebase](https://github.com/firebase/firebase-js-sdk). These dependencies need to be updated together.


Updates `undici` from 5.26.5 to 5.28.3
- [Release notes](https://github.com/nodejs/undici/releases)
- [Commits](https://github.com/nodejs/undici/compare/v5.26.5...v5.28.3)

Updates `firebase` from 10.8.0 to 10.8.1
- [Release notes](https://github.com/firebase/firebase-js-sdk/releases)
- [Changelog](https://github.com/firebase/firebase-js-sdk/blob/master/CHANGELOG.md)
- [Commits](https://github.com/firebase/firebase-js-sdk/compare/firebase@10.8.0...firebase@10.8.1)

---
updated-dependencies:
- dependency-name: undici dependency-type: indirect
- dependency-name: firebase dependency-type: direct:production ...